### PR TITLE
fix: GCC build errors and update README for GCC toolchain

### DIFF
--- a/Application/LvglDemoApp/LvglDemoApp.c
+++ b/Application/LvglDemoApp/LvglDemoApp.c
@@ -52,6 +52,7 @@ DisplayUefiLogo (
 }
 
 VOID
+EFIAPI
 LvglUefiDemo (
   VOID
   )

--- a/Application/LvglDemos/LvglDemos.c
+++ b/Application/LvglDemos/LvglDemos.c
@@ -16,8 +16,11 @@
 
 #include <Library/LvglLib.h>
 
-
 void lv_demo_keypad_encoder(void);
+
+VOID EFIAPI LvglDemoKeypadEncoderWrapper (VOID) {
+  lv_demo_keypad_encoder();
+}
 
 /**
   The user Entry Point for Application. The user code starts with this function
@@ -40,7 +43,7 @@ UefiMain (
   EFI_STATUS  Status;
 
   if (UefiLvglInit() == EFI_SUCCESS) {
-    Status = UefiLvglAppRegister (lv_demo_keypad_encoder);
+    Status = UefiLvglAppRegister (LvglDemoKeypadEncoderWrapper);
 
     if (!EFI_ERROR (Status)) {
       UefiLvglDeinit();

--- a/Library/LvglLib/lv_uefi_display.c
+++ b/Library/LvglLib/lv_uefi_display.c
@@ -21,7 +21,6 @@ static void uefi_disp_delete_evt_cb(lv_event_t * e)
 
 void uefi_disp_flush(lv_display_t * disp, const lv_area_t * area, lv_color32_t * color32_p)
 {
-  EFI_STATUS                         Status;
   UINTN                              Width, Heigth;
   uefi_disp_data_t                   *uefi_disp_data;
   UINTN                              Delta;
@@ -32,18 +31,18 @@ void uefi_disp_flush(lv_display_t * disp, const lv_area_t * area, lv_color32_t *
   Heigth = area->y2 - area->y1 + 1;
   Delta = uefi_disp_data->EfiGop->Mode->Info->HorizontalResolution * sizeof(EFI_GRAPHICS_OUTPUT_BLT_PIXEL);
 
-  Status = uefi_disp_data->EfiGop->Blt (
-                                     uefi_disp_data->EfiGop,
-                                     (EFI_GRAPHICS_OUTPUT_BLT_PIXEL *)color32_p,
-                                     EfiBltBufferToVideo,
-                                     (UINTN)area->x1,
-                                     (UINTN)area->y1,
-                                     (UINTN)area->x1,
-                                     (UINTN)area->y1,
-                                     Width,
-                                     Heigth,
-                                     Delta
-                                     );
+  uefi_disp_data->EfiGop->Blt (
+                            uefi_disp_data->EfiGop,
+                            (EFI_GRAPHICS_OUTPUT_BLT_PIXEL *)color32_p,
+                            EfiBltBufferToVideo,
+                            (UINTN)area->x1,
+                            (UINTN)area->y1,
+                            (UINTN)area->x1,
+                            (UINTN)area->y1,
+                            Width,
+                            Heigth,
+                            Delta
+                            );
 
   lv_display_flush_ready(disp);
 }


### PR DESCRIPTION
## Summary
- Remove unused `Status` variable in `lv_uefi_display.c` (`-Werror=unused-but-set-variable`)
- Add `EFIAPI` to `LvglUefiDemo` in `LvglDemoApp.c` (calling convention mismatch)
- Add forward declaration + `EFIAPI` wrapper for `lv_demo_keypad_encoder` in `LvglDemos.c`
- Update README with GCC build command and QEMU setup

Tested with GCC 13.3 on Ubuntu 24.04 x86_64.

Signed-off-by: hckaraca99 <hckaraca99@gmail.com>