### PR TITLE
feat: forward mouse wheel to LVGL pointer

### DIFF
--- a/Library/LvglLib/lv_port_indev.c
+++ b/Library/LvglLib/lv_port_indev.c
@@ -22,10 +22,21 @@ typedef struct {
   EFI_ABSOLUTE_POINTER_PROTOCOL  *AbsPointer;
   INTN                           LastCursorX;
   INTN                           LastCursorY;
+  UINT64                         LastAbsZ;
+  INT32                          WheelDelta;
   UINT32                         ActiveButtons;
   BOOLEAN                        LeftButton;
   BOOLEAN                        RightButton;
 } LVGL_UEFI_MOUSE;
+
+//
+// LVGL treats any non-zero pointer.diff as one full detent and scrolls by
+// scroll_limit (default 10px) per call (lv_indev.c:1638). QEMU usb-mouse can
+// send several wheel reports per perceived host wheel motion, so we ratchet:
+// accumulate raw Z counts and only emit one ±1 detent per N counts.
+// Lower this number = more sensitive. Raise = less sensitive.
+//
+#define LVGL_WHEEL_COUNTS_PER_DETENT  8
 
 /**********************
  *      TYPEDEFS
@@ -160,7 +171,7 @@ lv_indev_t * lv_uefi_keyboard_create(void)
 
 EFI_STATUS
 EFIAPI
-GetXY (
+GetXYZ (
   lv_indev_t * indev_drv
   )
 {
@@ -189,6 +200,9 @@ GetXY (
       }
       mLvglUefiMouse.LeftButton = AbsState.ActiveButtons & BIT0;
 
+      mLvglUefiMouse.WheelDelta += (INT32)(AbsState.CurrentZ - mLvglUefiMouse.LastAbsZ);
+      mLvglUefiMouse.LastAbsZ = AbsState.CurrentZ;
+
       return EFI_SUCCESS;
     }
   } else if (mLvglUefiMouse.SimplePointer != NULL) {
@@ -212,6 +226,8 @@ GetXY (
 
       mLvglUefiMouse.LeftButton = SimpleState.LeftButton;
       mLvglUefiMouse.RightButton = SimpleState.RightButton;
+
+      mLvglUefiMouse.WheelDelta += SimpleState.RelativeMovementZ;
 
       return EFI_SUCCESS;
     }
@@ -278,27 +294,27 @@ StartInit:
   DebugPrint (DEBUG_INFO, "Abs Pointer: %d\n", AbsPointerSupport);
   DebugPrint (DEBUG_INFO, "Simple Pointer: %d\n", SimplePointerSupport);
 
-  mLvglUefiMouse.AbsPointer = NULL;
+  mLvglUefiMouse.AbsPointer    = NULL;
+  mLvglUefiMouse.SimplePointer = NULL;
+  mLvglUefiMouse.LastAbsZ      = 0;
+  mLvglUefiMouse.WheelDelta    = 0;
+  mLvglUefiMouse.ActiveButtons = 0;
+  mLvglUefiMouse.LeftButton    = FALSE;
+  mLvglUefiMouse.RightButton   = FALSE;
+
   if (AbsPointerSupport) {
     Status = gBS->HandleProtocol (gST->ConsoleInHandle, &gEfiAbsolutePointerProtocolGuid, (VOID **)&AbsPointer);
     if (!EFI_ERROR (Status) && AbsPointer != NULL) {
-      // AbsPointer->Reset(AbsPointer, TRUE);
       mLvglUefiMouse.AbsPointer = AbsPointer;
     }
   }
 
-  mLvglUefiMouse.SimplePointer = NULL;
   if (SimplePointerSupport && !AbsPointerSupport) {
     Status = gBS->HandleProtocol (gST->ConsoleInHandle, &gEfiSimplePointerProtocolGuid, (VOID **)&SimplePointer);
     if (!EFI_ERROR (Status) && SimplePointer != NULL) {
-      // SimplePointer->Reset(SimplePointer, TRUE);
       mLvglUefiMouse.SimplePointer = SimplePointer;
     }
   }
-
-  mLvglUefiMouse.ActiveButtons = 0;
-  mLvglUefiMouse.LeftButton = FALSE;
-  mLvglUefiMouse.RightButton = FALSE;
 
   return Status;
 }
@@ -307,7 +323,7 @@ StartInit:
 static void mouse_read(lv_indev_t * indev_drv, lv_indev_data_t * data)
 {
 
-  GetXY(indev_drv);
+  GetXYZ(indev_drv);
   data->point.x = mLvglUefiMouse.LastCursorX;
   data->point.y = mLvglUefiMouse.LastCursorY;
   if (mLvglUefiMouse.LeftButton) {
@@ -316,6 +332,15 @@ static void mouse_read(lv_indev_t * indev_drv, lv_indev_data_t * data)
     data->state = LV_INDEV_STATE_RELEASED;
   }
 
+  if (mLvglUefiMouse.WheelDelta >= LVGL_WHEEL_COUNTS_PER_DETENT) {
+    data->enc_diff = 1;
+    mLvglUefiMouse.WheelDelta -= LVGL_WHEEL_COUNTS_PER_DETENT;
+  } else if (mLvglUefiMouse.WheelDelta <= -LVGL_WHEEL_COUNTS_PER_DETENT) {
+    data->enc_diff = -1;
+    mLvglUefiMouse.WheelDelta += LVGL_WHEEL_COUNTS_PER_DETENT;
+  } else {
+    data->enc_diff = 0;
+  }
 }
 
 
@@ -332,6 +357,7 @@ void lv_indev_set_cusor_start(lv_indev_t * indev)
     indev->pointer.act_point.y = ver_res / 2;
     mLvglUefiMouse.LastCursorX = hor_res / 2;
     mLvglUefiMouse.LastCursorY = ver_res / 2;
+    mLvglUefiMouse.WheelDelta = 0;
     mLvglUefiMouse.ActiveButtons = 0;
     mLvglUefiMouse.LeftButton = FALSE;
     mLvglUefiMouse.RightButton = FALSE;
@@ -388,6 +414,8 @@ void lv_port_indev_close()
   mLvglUefiMouse.SimplePointer = NULL;
   mLvglUefiMouse.LastCursorX = 0;
   mLvglUefiMouse.LastCursorY = 0;
+  mLvglUefiMouse.LastAbsZ = 0;
+  mLvglUefiMouse.WheelDelta = 0;
   mLvglUefiMouse.ActiveButtons = 0;
   mLvglUefiMouse.LeftButton = FALSE;
   mLvglUefiMouse.RightButton = FALSE;

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -41,7 +41,7 @@ build -p LvglPkg/LvglPkg.dsc -a AARCH64 -t GCC5 -b RELEASE
 ## TODO
 - [x] Absolute Pointer Mouse
 - [x] Simple Pointer Mouse
-- [ ] Mouse Wheel
+- [x] Mouse Wheel
 - [x] Log/Debug Print
 - [ ] File System
 - [ ] ~~VS2022~~/~~AARCH64-GCC~~/Clang


### PR DESCRIPTION
## Summary
- Add mouse wheel (scroll) support by tracking the Z-axis delta from `EFI_ABSOLUTE_POINTER_PROTOCOL` and `EFI_SIMPLE_POINTER_PROTOCOL`, then forwarding it to LVGL as `enc_diff`
- QEMU `usb-mouse` sends several wheel reports per host wheel tick, so a ratchet threshold (`LVGL_WHEEL_COUNTS_PER_DETENT`) accumulates raw counts and emits one ±1 detent per N counts
- Uses `ConsoleInHandle` for pointer protocol access (ConSplitter aggregate)

Signed-off-by: hckaraca99 <hckaraca99@gmail.com>