### PR TITLE
fix: lazy mouse indev creation via protocol install notification

### DIFF
--- a/Library/LvglLib/lv_port_indev.c
+++ b/Library/LvglLib/lv_port_indev.c
@@ -48,6 +48,17 @@ lv_indev_t * indev_keypad;
 
 LVGL_UEFI_MOUSE mLvglUefiMouse;
 
+//
+// Protocol-install notification: fires when any driver installs
+// EFI_ABSOLUTE_POINTER_PROTOCOL (e.g. when USB mouse binds during BDS
+// ConnectAll). At constructor time USB is not yet enumerated, so the
+// initial lv_uefi_mouse_create() call fails; this callback retries
+// once the pointer protocol actually appears.
+//
+STATIC EFI_EVENT    mPointerNotifyEvent        = NULL;
+STATIC VOID         *mPointerNotifyRegistration = NULL;
+STATIC lv_display_t *mPointerNotifyDisplay     = NULL;
+
 /**********************
  *      MACROS
  **********************/
@@ -339,11 +350,30 @@ void lv_indev_set_cusor_start(lv_indev_t * indev)
 
 lv_indev_t * lv_uefi_mouse_create(lv_display_t * disp)
 {
+    //
+    // Idempotent: if a pointer indev already exists, return it.
+    // This lets callers invoke lv_uefi_mouse_create() lazily — e.g. after BDS
+    // has connected USB — without worrying about whether the constructor-time
+    // attempt succeeded.
+    //
+    lv_indev_t * existing = NULL;
+    while ((existing = lv_indev_get_next(existing)) != NULL) {
+        if (lv_indev_get_type(existing) == LV_INDEV_TYPE_POINTER) {
+            return existing;
+        }
+    }
+
+    if (EfiMouseInit() != EFI_SUCCESS) {
+        return NULL;
+    }
+
     lv_indev_t * indev = lv_indev_create();
     LV_ASSERT_MALLOC(indev);
     if(indev == NULL) {
       return NULL;
     }
+
+    DebugPrint (DEBUG_INFO, "Create Mouse\n");
 
     lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
     lv_indev_set_read_cb(indev, mouse_read);
@@ -358,31 +388,59 @@ lv_indev_t * lv_uefi_mouse_create(lv_display_t * disp)
     return indev;
 }
 
-
+STATIC
+VOID
+EFIAPI
+OnPointerProtocolInstalled (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+    if (mPointerNotifyDisplay != NULL) {
+        lv_uefi_mouse_create (mPointerNotifyDisplay);
+    }
+}
 
 void lv_port_indev_init(lv_display_t * disp)
 {
+    lv_uefi_mouse_create(disp);
 
-    /*------------------
-     * Mouse
-     * -----------------*/
-
-    /*Initialize your mouse if you have*/
-    if (EfiMouseInit() == EFI_SUCCESS) {
-      DebugPrint (DEBUG_INFO, "Create Mouse\n");
-      lv_uefi_mouse_create(disp);
-    }
-
-
-    /*------------------
-     * Keypad
-     * -----------------*/
     lv_uefi_keyboard_create();
 
+    //
+    // If the mouse couldn't be created yet (USB not connected at this point
+    // in boot), register for notification when the pointer protocol shows up.
+    //
+    if (mPointerNotifyEvent == NULL) {
+        EFI_STATUS Status;
+
+        mPointerNotifyDisplay = disp;
+
+        Status = gBS->CreateEvent (
+                       EVT_NOTIFY_SIGNAL,
+                       TPL_CALLBACK,
+                       OnPointerProtocolInstalled,
+                       NULL,
+                       &mPointerNotifyEvent
+                       );
+        if (!EFI_ERROR (Status)) {
+            gBS->RegisterProtocolNotify (
+                   &gEfiAbsolutePointerProtocolGuid,
+                   mPointerNotifyEvent,
+                   &mPointerNotifyRegistration
+                   );
+        }
+    }
 }
 
 void lv_port_indev_close()
 {
+  if (mPointerNotifyEvent != NULL) {
+    gBS->CloseEvent (mPointerNotifyEvent);
+    mPointerNotifyEvent         = NULL;
+    mPointerNotifyRegistration  = NULL;
+    mPointerNotifyDisplay       = NULL;
+  }
 
   mLvglUefiMouse.AbsPointer = NULL;
   mLvglUefiMouse.SimplePointer = NULL;

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -22,6 +22,15 @@ build -p LvglPkg/LvglPkg.dsc -a AARCH64 -t GCC5 -b RELEASE
    - Call `UefiLvglAppRegister (MyApp)` to show `MyApp`
    - ~~Call `UefiLvglDeinit()` to do deinit, and you may need another code to do clear up for `MyApp`~~
 
+### DXE_DRIVER consumers
+
+LvglLib is also consumable by DXE drivers (e.g. a custom HII display engine).
+USB mouse protocols are typically not available at DXE dispatch time — they
+appear later during BDS `ConnectAll`. LvglLib registers a protocol-install
+notification on `gEfiAbsolutePointerProtocolGuid` at init time and creates
+the mouse indev lazily when the USB mouse binds, so no extra work is required
+from the consumer.
+
 ## Demo
 
 - [UefiDashboard.efi](./Demo/Bin/UefiDashboard.efi)


### PR DESCRIPTION
## Summary

Fixes a DXE-timing bug where the mouse is unusable when LvglLib is consumed by a `DXE_DRIVER` (e.g. a display engine driver loaded during DXE dispatch).

### Root cause

`LvglLibConstructor` runs during DXE dispatch — before BDS calls `ConnectAll` and enumerates USB devices. `EfiMouseInit()` finds no `AbsolutePointer`/`SimplePointer` protocols and returns `EFI_UNSUPPORTED`, so no mouse indev is ever created. By the time the driver actually renders, `UefiLvglInit()` short-circuits (`mUefiLvglInitDone == TRUE`) and never retries.

This does not affect `UEFI_APPLICATION` consumers (like the existing demos) because applications run after BDS, when USB is already up.

### Fix

- Make `lv_uefi_mouse_create()` idempotent: early-return if a pointer indev already exists, and call `EfiMouseInit()` internally.
- Register a protocol-install notification on `gEfiAbsolutePointerProtocolGuid` from `lv_port_indev_init()`. When USB mouse binds during BDS `ConnectAll`, the callback fires and creates the indev lazily.
- Close the event in `lv_port_indev_close()`.

No change required at any consumer boundary — the library handles the timing itself.

## Test plan

- [x] Builds clean with `GCC` toolchain for `OvmfPkgX64.dsc`
- [x] `UEFI_APPLICATION` demos (`LvglDemos.efi`, `UefiDashboard.efi`) still work — initial `lv_uefi_mouse_create()` call succeeds since USB is already up at app launch; notify is registered but harmless.
- [x] `DXE_DRIVER` consumer (LvglDisplayEngineDxe) now gets a working mouse cursor in QEMU with `-device usb-mouse`.